### PR TITLE
Get statistics by account name

### DIFF
--- a/statistics-service/src/main/kotlin/com/piggymetrics/kt/statistics/controllers/StatisticsController.kt
+++ b/statistics-service/src/main/kotlin/com/piggymetrics/kt/statistics/controllers/StatisticsController.kt
@@ -3,14 +3,16 @@ package com.piggymetrics.kt.statistics.controllers
 import com.piggymetrics.kt.statistics.domain.Account
 import com.piggymetrics.kt.statistics.domain.timeseries.DataPoint
 import com.piggymetrics.kt.statistics.services.StatisticsService
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import javax.validation.Valid
+import javax.validation.constraints.NotBlank
 
 @RestController
 class StatisticsController(private val statisticsService: StatisticsService) {
+
+    @GetMapping("/{accountName}")
+    fun getStatisticsByAccountName(@NotBlank @PathVariable accountName: String): List<DataPoint> =
+            statisticsService.findByAccountName(accountName)
 
     @PutMapping("/{accountName}")
     fun saveAccountStatistics(@PathVariable accountName: String, @Valid @RequestBody account: Account) {

--- a/statistics-service/src/main/kotlin/com/piggymetrics/kt/statistics/services/StatisticsService.kt
+++ b/statistics-service/src/main/kotlin/com/piggymetrics/kt/statistics/services/StatisticsService.kt
@@ -4,5 +4,6 @@ import com.piggymetrics.kt.statistics.domain.Account
 import com.piggymetrics.kt.statistics.domain.timeseries.DataPoint
 
 interface StatisticsService {
+    fun findByAccountName(accountName: String): List<DataPoint>
     fun save(accountName: String, account: Account): DataPoint
 }

--- a/statistics-service/src/main/kotlin/com/piggymetrics/kt/statistics/services/StatisticsServiceImpl.kt
+++ b/statistics-service/src/main/kotlin/com/piggymetrics/kt/statistics/services/StatisticsServiceImpl.kt
@@ -20,6 +20,8 @@ import java.util.*
 class StatisticsServiceImpl(private val ratesService: ExchangeRatesService,
                             private val dataPointRepository: DataPointRepository) : StatisticsService {
 
+    override fun findByAccountName(accountName: String): List<DataPoint> = dataPointRepository.findByIdAccount(accountName)
+
     override fun save(accountName: String, account: Account): DataPoint {
         val instant = LocalDate.now().atStartOfDay().atZone(ZoneId.systemDefault()).toInstant()
         val dataPointId = DataPointId(accountName, Date.from(instant))


### PR DESCRIPTION
A new endpoint is added to get statistics by account name.

The DataPoint response from saveAccountStatistics endpoint is removed. There is no need to return the DataPoint response. The official piggymetrics project doesn't return the DataPoint.